### PR TITLE
URL extraction & saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ As per TIFF Terms and Conditions, this data is being used soley for educational,
 This process takes about 2 minutes on MacBook Air (13-inch, Early 2015) 1.6 GHz Intel Core i5 and at 250Mbps internet connection. This process will take much longer on a slower internet connection and slower processor.
 
 ### To Do
-* Make the URLs.json file with Nokogiri, requires site interaction to load all the data before parsing the dom for the urls of films.
+~~* Make the URLs.json file with Nokogiri, requires site interaction to load all the data before parsing the dom for the urls of films.~~

--- a/app.rb
+++ b/app.rb
@@ -2,8 +2,27 @@ require 'nokogiri'
 require 'open-uri'
 require 'json'
 
-urls_file = File.read("urls.json")
-urls = JSON.parse(urls_file)
+urls_file = 'urls.json'
+
+if File.file?(urls_file)
+  urls = JSON.parse(File.read(urls_file))
+else
+  urls = Array.new
+  urlsDOM = Nokogiri::HTML(open('http://tiff.net/?filter=festival'), nil, 'utf-8')
+  tiff_urls = urlsDOM.css("#calendar .container .row .card .card-title")
+
+  tiff_urls.each do |url|
+    # don't strip spaces in urls, gsub them with url encoded %20 instead
+    href = url['href'].gsub(' ', '%20')
+    if href.match(/^films/)
+      urls.push("http://tiff.net/#{href}")
+    end
+  end
+  File.open("urls.json", "w") do |f|
+    f.write(JSON.pretty_generate(urls))
+  end
+end
+
 films = Array.new
 
 for url in urls do


### PR DESCRIPTION
Here's a PR to extract URLs from the TIFF site and save to `urls.json` if it does not exist.